### PR TITLE
New spec SDK additions

### DIFF
--- a/faunadb/newspec.go
+++ b/faunadb/newspec.go
@@ -37,3 +37,9 @@ func Reduce(coll, init, lambda interface{}) Expr {
 func Count(coll interface{}) Expr   { return fn1("count", coll) }
 func Average(coll interface{}) Expr { return fn1("average", coll) }
 func Sum(coll interface{}) Expr     { return fn1("sum", coll) }
+
+// Reverse(set/array/page)
+// We will add a Reverse() function which can take an array, page, or set, and return the reversed version.
+func Reverse(coll interface{}) Expr {
+	return fn1("reduce", coll)
+}

--- a/faunadb/newspec.go
+++ b/faunadb/newspec.go
@@ -26,6 +26,29 @@ func Range(set interface{}, options ...OptionalParameter) Expr {
 	return fn1("range", set, options...)
 }
 
+// Other range-like predicates to be added are RangeLT, RangeLTE, RangeGT, and RangeGTE,
+// which let you bound the set only on one side, or can be combined to specify upper and lower bound exclusivity.
+
+// RangeLT equals field_lt (less than)
+func RangeLT(set, value interface{}) Expr {
+	return fn2("range_lt", set, "value", value)
+}
+
+// RangeLTE equals field_lte (less than or equals)
+func RangeLTE(set, value interface{}) Expr {
+	return fn2("range_lte", set, "value", value)
+}
+
+// RangeGT equals field_gt (greater than)
+func RangeGT(set, value interface{}) Expr {
+	return fn2("range_gt", set, "value", value)
+}
+
+// RangeGTE equals field_gte (greater than or equals)
+func RangeGTE(set, value interface{}) Expr {
+	return fn2("range_gte", set, "value", value)
+}
+
 // Reduce function which may be used on arrays, pages or sets. This will behave similarly to foldLeft or reduce in functional languages.
 // Reduce(set/array/page, init, fn)
 func Reduce(coll, init, lambda interface{}) Expr {

--- a/faunadb/newspec.go
+++ b/faunadb/newspec.go
@@ -25,3 +25,9 @@ func UpperBound(ref interface{}) OptionalParameter {
 func Range(set interface{}, options ...OptionalParameter) Expr {
 	return fn1("range", set, options...)
 }
+
+// Reduce function which may be used on arrays, pages or sets. This will behave similarly to foldLeft or reduce in functional languages.
+// Reduce(set/array/page, init, fn)
+func Reduce(coll, init, lambda interface{}) Expr {
+	return fn3("reduce", lambda, "init", init, "collection", coll)
+}

--- a/faunadb/newspec.go
+++ b/faunadb/newspec.go
@@ -31,3 +31,9 @@ func Range(set interface{}, options ...OptionalParameter) Expr {
 func Reduce(coll, init, lambda interface{}) Expr {
 	return fn3("reduce", lambda, "init", init, "collection", coll)
 }
+
+// Aliases for commonly used reducers, which may be used on arrays, pages or sets.
+// Note: Min, Max already exist
+func Count(coll interface{}) Expr   { return fn1("count", coll) }
+func Average(coll interface{}) Expr { return fn1("average", coll) }
+func Sum(coll interface{}) Expr     { return fn1("sum", coll) }

--- a/faunadb/newspec.go
+++ b/faunadb/newspec.go
@@ -1,0 +1,27 @@
+package faunadb
+
+// LowerBound is a new optional parameter
+func LowerBound(ref interface{}) OptionalParameter {
+	return func(fn unescapedObj) {
+		fn["lowerbound"] = wrap(ref)
+	}
+}
+
+// UpperBound is a new optional parameter
+func UpperBound(ref interface{}) OptionalParameter {
+	return func(fn unescapedObj) {
+		fn["upperbound"] = wrap(ref)
+	}
+}
+
+// Range will provide the ability to limit a set based on lower and upper bounds of its natural order.
+//
+// Parameters:
+//  set SetRef - A set reference
+//
+// Optional parameters:
+//  Range(set, lowerBound, upperBound)
+//
+func Range(set interface{}, options ...OptionalParameter) Expr {
+	return fn1("range", set, options...)
+}

--- a/faunadb/newspec.go
+++ b/faunadb/newspec.go
@@ -43,3 +43,10 @@ func Sum(coll interface{}) Expr     { return fn1("sum", coll) }
 func Reverse(coll interface{}) Expr {
 	return fn1("reduce", coll)
 }
+
+// Documents(set/array/page)
+// We will add a Documents() built-in which will allow iterating through all of the documents in a collection. Combined with Filter(), Reduce(), Count(), etc.
+// This will allow for arbitrary querying of a collection without the need for indexes. Initially this functionality will be backed by a scan of the collection.
+func Documents(coll interface{}) Expr {
+	return fn1("documents", coll)
+}

--- a/faunadb/newspec_test.go
+++ b/faunadb/newspec_test.go
@@ -26,6 +26,25 @@ func TestSerializeRange(t *testing.T) {
 	)
 }
 
+func TestSerializeRangeComparisons(t *testing.T) {
+	assertJSON(t,
+		RangeLT(Match("coll_by_x"), 1),
+		`{"range_lt":{"match":"coll_by_x"},"value":1}`,
+	)
+	assertJSON(t,
+		RangeLTE(Match("coll_by_x"), 1),
+		`{"range_lte":{"match":"coll_by_x"},"value":1}`,
+	)
+	assertJSON(t,
+		RangeGT(Match("coll_by_x"), 1),
+		`{"range_gt":{"match":"coll_by_x"},"value":1}`,
+	)
+	assertJSON(t,
+		RangeGTE(Match("coll_by_x"), 1),
+		`{"range_gte":{"match":"coll_by_x"},"value":1}`,
+	)
+}
+
 // Filter(set/array/page, predicate)
 // Filter() currently takes an array or page and filters its elements based on a predicate function.
 // It will be enhanced to work on sets, in order to enable more ergonomic pagination and ability to compose it with other set modifiers.

--- a/faunadb/newspec_test.go
+++ b/faunadb/newspec_test.go
@@ -1,0 +1,24 @@
+package faunadb
+
+import (
+	"testing"
+)
+
+// Test with e.g.:
+// FAUNA_ROOT_KEY="dummy" go test -timeout 30s github.com/fauna/faunadb-go/faunadb -count=1 -run TestSerializeRange
+func TestSerializeRange(t *testing.T) {
+	assertJSON(t,
+		Range(Ref("databases")),
+		`{"range":{"@ref":"databases"}}`,
+	)
+
+	assertJSON(t,
+		Range(Match("users_by_name"), LowerBound("Brown"), UpperBound("Smith")),
+		`{"lowerbound":"Brown","range":{"match":"users_by_name"},"upperbound":"Smith"}`,
+	)
+
+	assertJSON(t,
+		Range(Match("users_by_last_first"), LowerBound(Arr{"Brown", "A"}), UpperBound("Smith")),
+		`{"lowerbound":["Brown","A"],"range":{"match":"users_by_last_first"},"upperbound":"Smith"}`,
+	)
+}

--- a/faunadb/newspec_test.go
+++ b/faunadb/newspec_test.go
@@ -91,7 +91,7 @@ func TestSerializeReverse(t *testing.T) {
 }
 
 // Count(), Average(), Sum(), Min(), Max()
-func TestReducerAliases(t *testing.T) {
+func TestSerializeReducerAliases(t *testing.T) {
 	assertJSON(t,
 		Min(Arr{1, 2, 3}),
 		`{"min":[1,2,3]}`,
@@ -111,5 +111,17 @@ func TestReducerAliases(t *testing.T) {
 	assertJSON(t,
 		Sum(Arr{1, 2, 3}),
 		`{"sum":[1,2,3]}`,
+	)
+}
+
+func TestSerializeDocuments(t *testing.T) {
+	assertJSON(t,
+		Documents(Arr{1, 2, 3}),
+		`{"documents":[1,2,3]}`,
+	)
+
+	assertJSON(t,
+		Documents(SetRefV{ObjectV{"name": StringV("a")}}),
+		`{"documents":{"@set":{"name":"a"}}}`,
 	)
 }

--- a/faunadb/newspec_test.go
+++ b/faunadb/newspec_test.go
@@ -6,6 +6,7 @@ import (
 
 // Test with e.g.:
 // FAUNA_ROOT_KEY="dummy" go test -timeout 30s github.com/fauna/faunadb-go/faunadb -count=1 -run TestSerializeRange
+// FAUNA_ROOT_KEY="dummy" go test github.com/fauna/faunadb-go/faunadb -run TestSerialize
 
 // Range(set, lowerBound, upperBound)
 func TestSerializeRange(t *testing.T) {

--- a/faunadb/newspec_test.go
+++ b/faunadb/newspec_test.go
@@ -26,7 +26,6 @@ func TestSerializeRange(t *testing.T) {
 }
 
 // Filter(set/array/page, predicate)
-//
 // Filter() currently takes an array or page and filters its elements based on a predicate function.
 // It will be enhanced to work on sets, in order to enable more ergonomic pagination and ability to compose it with other set modifiers.
 func TestSerializeFilterSet(t *testing.T) {
@@ -37,13 +36,31 @@ func TestSerializeFilterSet(t *testing.T) {
 }
 
 // Map(set/array/page, fn)
-//
 // Map will be enhanced to work on sets in addition to pages and arrays.
 // This will allow for more ergonomic pagination and combination with functions like Take() and Drop().
 func TestSerializeMapSet(t *testing.T) {
 	assertJSON(t,
 		Map(SetRefV{ObjectV{"name": StringV("a")}}, Lambda("x", Var("x"))),
 		`{"collection":{"@set":{"name":"a"}},"map":{"expr":{"var":"x"},"lambda":"x"}}`,
+	)
+}
+
+// Drop(set/array/page, num)
+// We will enhance the Drop() function to be able to take a set and return a set-like object which excludes the first N elements. This is equivalent to OFFSET in MySQL.
+func TestSerializeDropSet(t *testing.T) {
+	assertJSON(t,
+		Drop(2, SetRefV{ObjectV{"name": StringV("a")}}),
+		`{"collection":{"@set":{"name":"a"}},"drop":2}`,
+	)
+}
+
+// Take(set/array/page, num)
+// We will enhance the Take() function to be able to take a set and return an array of the first N elements.
+// Combined with take() when used with drop(), can be used to simulate offset/limit style pagination.
+func TestSerializeTakeSet(t *testing.T) {
+	assertJSON(t,
+		Take(2, SetRefV{ObjectV{"name": StringV("a")}}),
+		`{"collection":{"@set":{"name":"a"}},"take":2}`,
 	)
 }
 
@@ -55,6 +72,7 @@ func TestSerializeReduce(t *testing.T) {
 	)
 }
 
+// Count(), Average(), Sum(), Min(), Max()
 func TestReducerAliases(t *testing.T) {
 	assertJSON(t,
 		Min(Arr{1, 2, 3}),

--- a/faunadb/newspec_test.go
+++ b/faunadb/newspec_test.go
@@ -6,6 +6,10 @@ import (
 
 // Test with e.g.:
 // FAUNA_ROOT_KEY="dummy" go test -timeout 30s github.com/fauna/faunadb-go/faunadb -count=1 -run TestSerializeRange
+
+// Range(set, lowerBound, upperBound)
+//
+// Range() will provide the ability to limit a set based on lower and upper bounds of its natural order.
 func TestSerializeRange(t *testing.T) {
 	assertJSON(t,
 		Range(Ref("databases")),
@@ -20,5 +24,27 @@ func TestSerializeRange(t *testing.T) {
 	assertJSON(t,
 		Range(Match("users_by_last_first"), LowerBound(Arr{"Brown", "A"}), UpperBound("Smith")),
 		`{"lowerbound":["Brown","A"],"range":{"match":"users_by_last_first"},"upperbound":"Smith"}`,
+	)
+}
+
+// Filter(set/array/page, predicate)
+//
+// Filter() currently takes an array or page and filters its elements based on a predicate function.
+// It will be enhanced to work on sets, in order to enable more ergonomic pagination and ability to compose it with other set modifiers.
+func TestSerializeFilterSet(t *testing.T) {
+	assertJSON(t,
+		Filter(SetRefV{ObjectV{"name": StringV("a")}}, Lambda("x", Var("x"))),
+		`{"collection":{"@set":{"name":"a"}},"filter":{"expr":{"var":"x"},"lambda":"x"}}`,
+	)
+}
+
+// Map(set/array/page, fn)
+//
+// Map will be enhanced to work on sets in addition to pages and arrays.
+// This will allow for more ergonomic pagination and combination with functions like Take() and Drop().
+func TestSerializeMapSet(t *testing.T) {
+	assertJSON(t,
+		Map(SetRefV{ObjectV{"name": StringV("a")}}, Lambda("x", Var("x"))),
+		`{"collection":{"@set":{"name":"a"}},"map":{"expr":{"var":"x"},"lambda":"x"}}`,
 	)
 }

--- a/faunadb/newspec_test.go
+++ b/faunadb/newspec_test.go
@@ -8,8 +8,6 @@ import (
 // FAUNA_ROOT_KEY="dummy" go test -timeout 30s github.com/fauna/faunadb-go/faunadb -count=1 -run TestSerializeRange
 
 // Range(set, lowerBound, upperBound)
-//
-// Range() will provide the ability to limit a set based on lower and upper bounds of its natural order.
 func TestSerializeRange(t *testing.T) {
 	assertJSON(t,
 		Range(Ref("databases")),
@@ -54,5 +52,28 @@ func TestSerializeReduce(t *testing.T) {
 	assertJSON(t,
 		Reduce(Arr{1, 2, 3}, 0, Lambda("x", Var("x"))),
 		`{"collection":[1,2,3],"init":0,"reduce":{"expr":{"var":"x"},"lambda":"x"}}`,
+	)
+}
+
+func TestReducerAliases(t *testing.T) {
+	assertJSON(t,
+		Min(Arr{1, 2, 3}),
+		`{"min":[1,2,3]}`,
+	)
+	assertJSON(t,
+		Max(Arr{1, 2, 3}),
+		`{"max":[1,2,3]}`,
+	)
+	assertJSON(t,
+		Count(Arr{1, 2, 3}),
+		`{"count":[1,2,3]}`,
+	)
+	assertJSON(t,
+		Average(Arr{1, 2, 3}),
+		`{"average":[1,2,3]}`,
+	)
+	assertJSON(t,
+		Sum(Arr{1, 2, 3}),
+		`{"sum":[1,2,3]}`,
 	)
 }

--- a/faunadb/newspec_test.go
+++ b/faunadb/newspec_test.go
@@ -70,6 +70,24 @@ func TestSerializeReduce(t *testing.T) {
 		Reduce(Arr{1, 2, 3}, 0, Lambda("x", Var("x"))),
 		`{"collection":[1,2,3],"init":0,"reduce":{"expr":{"var":"x"},"lambda":"x"}}`,
 	)
+
+	assertJSON(t,
+		Reduce(SetRefV{ObjectV{"name": StringV("a")}}, 0, Lambda("x", Var("x"))),
+		`{"collection":{"@set":{"name":"a"}},"init":0,"reduce":{"expr":{"var":"x"},"lambda":"x"}}`,
+	)
+}
+
+// Reduce(set/array/page, init, fn)
+func TestSerializeReverse(t *testing.T) {
+	assertJSON(t,
+		Reverse(Arr{1, 2, 3}),
+		`{"reduce":[1,2,3]}`,
+	)
+
+	assertJSON(t,
+		Reverse(SetRefV{ObjectV{"name": StringV("a")}}),
+		`{"reduce":{"@set":{"name":"a"}}}`,
+	)
 }
 
 // Count(), Average(), Sum(), Min(), Max()

--- a/faunadb/newspec_test.go
+++ b/faunadb/newspec_test.go
@@ -48,3 +48,11 @@ func TestSerializeMapSet(t *testing.T) {
 		`{"collection":{"@set":{"name":"a"}},"map":{"expr":{"var":"x"},"lambda":"x"}}`,
 	)
 }
+
+// Reduce(set/array/page, init, fn)
+func TestSerializeReduce(t *testing.T) {
+	assertJSON(t,
+		Reduce(Arr{1, 2, 3}, 0, Lambda("x", Var("x"))),
+		`{"collection":[1,2,3],"init":0,"reduce":{"expr":{"var":"x"},"lambda":"x"}}`,
+	)
+}


### PR DESCRIPTION
- Added:
	- `Range(set, lowerBound, upperBound)`
		- `RangeLT, RangeLTE, RangeGT, and RangeGTE`
	- `Reduce(set/array/page, init, fn)`
	- `Reverse(set/array/page)`
	- `Documents(set/array/page)`
- New optional parameters:
	- `LowerBound`, `UpperBound`
- Aliases for commonly used reducers:
	- `Count(), Average(), Sum()`
- Additional tests for `Set` support:
	- `Filter(set/array/page, predicate)`
	- `Map(set/array/page, fn)`
	- `Drop(set/array/page, num)`
	- `Take(set/array/page, num)`