### PR TITLE
Add new InPtr, fix LetPtr

### DIFF
--- a/faunadb/custom.go
+++ b/faunadb/custom.go
@@ -11,7 +11,19 @@ func unescapedBindings(obj Obj) unescapedObj {
 	return res
 }
 
-// LetRef binds values to one or more variables as go pointer.
+// InPtr is In with pointer bindings support
+func (lb *LetBuilder) InPtr(in Expr) Expr {
+	// return fn2("let", lb.bindings, "in", in)
+	// return LetPtr(lb.bindings, &in)
+	return unescapedObj{
+		"let": wrap(lb.bindings),
+		"in":  in,
+	}
+}
+
+// LetPtr is the original Let implementation with pointer support in bindings
+// Note: Has been updated to bindings in an array similar to builtin LetBuilder
+// Consider using `Let().Bind().InPtr(&in)` instead
 //
 // Parameters:
 //  bindings Object - An object binding a variable name to a value.
@@ -22,9 +34,8 @@ func unescapedBindings(obj Obj) unescapedObj {
 //
 // See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
 func LetPtr(bindings Obj, in *Obj) Expr {
-
 	return unescapedObj{
-		"let": wrap(unescapedBindings(bindings)),
+		"let": wrap(Arr{unescapedBindings(bindings)}),
 		"in":  in,
 	}
 }


### PR DESCRIPTION
- Wraps bindings of `LetPtr` output in array
- Adds `InPtr` to support pointers with new `LetBuilder` (e.g. ``Let().Bind().InPtr(&in)``)
- Adds test for everything including Fail testing for Original `Let` method's lack of Pointer support